### PR TITLE
fix: update ui test case

### DIFF
--- a/QMUIDemoUITests/QDUITestTools.m
+++ b/QMUIDemoUITests/QDUITestTools.m
@@ -16,7 +16,15 @@
 
 - (BOOL)qd_hasKeyboardFocus {
     // https://stackoverflow.com/a/35915719/4250833
-    return [self qmui_valueForKey:@"hasKeyboardFocus"];
+    if (@available(iOS 13.0, *)) {
+        if ([self isKindOfClass:[UIView class]] && QMUICMIActivated && !IgnoreKVCAccessProhibited) {
+            BeginIgnoreUIKVCAccessProhibited
+            id value = [self valueForKey:@"hasKeyboardFocus"];
+            EndIgnoreUIKVCAccessProhibited
+            return value;
+        }
+    }
+    return [self valueForKey:@"hasKeyboardFocus"];
 }
 
 - (void)qd_clearText {

--- a/QMUIDemoUITests/QMUIDemoUITests.m
+++ b/QMUIDemoUITests/QMUIDemoUITests.m
@@ -63,8 +63,10 @@
     [textView typeText:@"string to be copied"];
     XCTAssertFalse(self.app.menuItems.count);
     [textView pressForDuration:1];
-    XCTAssertTrue(self.app.menuItems.count);
+    sleep(1.5);
+    XCTAssertTrue([[self.app menuItems] count]);
     [self.app qd_tapMenuItem:QDUITestMenuItemSelectAll];
+    sleep(1.5);
     [self.app qd_tapMenuItem:QDUITestMenuItemCopy];
     sleep(1.5);
     NSLog(@"UIPasteboard.generalPasteboard.string = %@", UIPasteboard.generalPasteboard.string);
@@ -83,7 +85,8 @@
     sleep(2);// 等待 QMUITips 消失才能点击 textView
     
     // 粘贴过来的一大段文字也要自动截断
-    [textView doubleTap];
+    [textView tap];
+    sleep(1.5);
     [self.app qd_tapMenuItem:QDUITestMenuItemSelectAll];
     [self.app.keys[@"delete"] tap];
     NSString *pasteString = @"这是一段粘贴过来的长文本，末尾理应会被截断。这是一段粘贴过来的长文本，末尾理应会被截断。这是一段粘贴过来的长文本，末尾理应会被截断。这是一段粘贴过来的长文本，末尾理应会被截断。这是一段粘贴过来的长文本，末尾理应会被截断。";


### PR DESCRIPTION
1. 增加一些时间间隔保证操作完成。（例如全选之后立马复制有时候有bug）

2. 改动 `qd_hasKeyboardFocus`, 是因为call `qmui_valueForKey` 会导致 `unrecognized selector sent to instance` error。

3 改动double tap to tap, 因为double tap会自动选择离光标最近几个字，不会出现全选选项。